### PR TITLE
Add language section

### DIFF
--- a/_data/languages/cs.yml
+++ b/_data/languages/cs.yml
@@ -1,0 +1,2 @@
+language: עברית
+code: he

--- a/_data/languages/de.yml
+++ b/_data/languages/de.yml
@@ -1,0 +1,2 @@
+language: العربية
+code: ar

--- a/_data/languages/el.yml
+++ b/_data/languages/el.yml
@@ -1,0 +1,2 @@
+language: Svenska
+code: sv

--- a/_data/languages/en.yml
+++ b/_data/languages/en.yml
@@ -1,0 +1,2 @@
+language: English
+code: en

--- a/_data/languages/es.yml
+++ b/_data/languages/es.yml
@@ -1,0 +1,2 @@
+language: Español
+code: es

--- a/_data/languages/he.yml
+++ b/_data/languages/he.yml
@@ -1,0 +1,2 @@
+language: Czech
+code: cs

--- a/_data/languages/hi.yml
+++ b/_data/languages/hi.yml
@@ -1,0 +1,2 @@
+language: Українська
+code: uk

--- a/_data/languages/hi.yml
+++ b/_data/languages/hi.yml
@@ -1,2 +1,2 @@
-language: Українська
-code: uk
+language: Hindi
+code: hi

--- a/_data/languages/it.yml
+++ b/_data/languages/it.yml
@@ -1,0 +1,2 @@
+language: Español
+code: es

--- a/_data/languages/it.yml
+++ b/_data/languages/it.yml
@@ -1,2 +1,2 @@
-language: Español
-code: es
+language: Italiano
+code: it

--- a/_data/languages/ja.yml
+++ b/_data/languages/ja.yml
@@ -1,0 +1,2 @@
+language: ภาษาไทย
+code: th

--- a/_data/languages/pt-br.yml
+++ b/_data/languages/pt-br.yml
@@ -1,0 +1,2 @@
+language: Português (Brasil)
+code: pt-br

--- a/_data/languages/sv.yml
+++ b/_data/languages/sv.yml
@@ -1,0 +1,2 @@
+language: Svenska
+code: sv

--- a/_data/languages/uk.yml
+++ b/_data/languages/uk.yml
@@ -1,0 +1,2 @@
+language: Українська
+code: uk

--- a/_data/languages/zh-1.yml
+++ b/_data/languages/zh-1.yml
@@ -1,2 +1,0 @@
-language: 中文
-code: zh

--- a/_data/languages/zh-1.yml
+++ b/_data/languages/zh-1.yml
@@ -1,0 +1,2 @@
+language: 中文
+code: zh

--- a/_data/languages/zh.yml
+++ b/_data/languages/zh.yml
@@ -1,2 +1,2 @@
-language: Português (Brasil)
-code: pt-br
+language: 中文
+code: zh

--- a/_data/languages/zh.yml
+++ b/_data/languages/zh.yml
@@ -1,0 +1,2 @@
+language: Português (Brasil)
+code: pt-br

--- a/_faq/map-layout-faq-question-how-can-i-prepare-my-home-and-family.md
+++ b/_faq/map-layout-faq-question-how-can-i-prepare-my-home-and-family.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: Should I wear a face mask?

--- a/_faq/map-layout-faq-question-how-is-covid-19-transmitted.md
+++ b/_faq/map-layout-faq-question-how-is-covid-19-transmitted.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: How is COVID-19 transmitted?

--- a/_faq/map-layout-faq-question-how-is-covid-19-treated.md
+++ b/_faq/map-layout-faq-question-how-is-covid-19-treated.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: How is COVID-19 treated?

--- a/_faq/map-layout-faq-question-what-are-the-symptoms-of-covid-19.md
+++ b/_faq/map-layout-faq-question-what-are-the-symptoms-of-covid-19.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: What are the symptoms of COVID-19?

--- a/_faq/map-layout-faq-question-what-is-covid-19.md
+++ b/_faq/map-layout-faq-question-what-is-covid-19.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: What is COVID-19?

--- a/_faq/map-layout-faq-question-what-should-i-do-if-i-believe-that-i-have-covid-19.md
+++ b/_faq/map-layout-faq-question-what-should-i-do-if-i-believe-that-i-have-covid-19.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: What should I do if I believe that I have COVID-19?

--- a/_faq/map-layout-faq-question-why-are-people-so-afraid-of-this-outbreak.md
+++ b/_faq/map-layout-faq-question-why-are-people-so-afraid-of-this-outbreak.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: "Why are people so afraid of this outbreak, isn't it just like the normal flu?"

--- a/_faq/map-layout-faq-question-will-warm-weather-stop-the-outbreak.md
+++ b/_faq/map-layout-faq-question-will-warm-weather-stop-the-outbreak.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: Will warm weather stop the outbreak?

--- a/_faq/map-layout-faq-question-wont-the-outbreak-happen-no-matter-what-we-do.md
+++ b/_faq/map-layout-faq-question-wont-the-outbreak-happen-no-matter-what-we-do.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: faq
 layout: page
 title: How can I protect myself and others from this virus?

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,3 +1,10 @@
+{% if page.dir == '/' %}
+  {% assign lang = 'en' %}
+{% else %}
+  {% assign lang = page.dir | remove: "/" %}
+{% endif %}
+
+
 <!DOCTYPE html>
 <html lang="en-GB">
   <head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,7 +38,7 @@
           <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
             {% for language_hash in site.data.languages %}
               {% assign language = language_hash[1] %}
-              <li><a href="/{{ language.code }}" class="p-subnav__item">{{ language.language }}</a></li>
+              <li><a href="/{% if language.code != 'en' %}{{ language.code }}{% endif %}" class="p-subnav__item">{{ language.language }}</a></li>
             {% endfor %}
             <li><a href="https://ru.endcoronavirus.org/" class="p-subnav__item">русский</a></li>
             <li><a href="https://pt.endcoronavirus.org/" class="p-subnav__item">Português</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,25 +36,14 @@
         <li class="p-navigation__item p-subnav" role="menuitem" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-subnav__toggle p-navigation__link">Languages</a>
           <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
-            <li><a href="/hi" class="p-subnav__item">Hindi</a></li>
-            <li><a href="/uk" class="p-subnav__item">Українська</a></li>
-            <li><a href="/el" class="p-subnav__item">Ελληνικά</a></li>
-            <li><a href="/sv" class="p-subnav__item">Svenska</a></li>
-            <li><a href="/zh" class="p-subnav__item">中文</a></li>
-            <li><a href="/pt-br" class="p-subnav__item">Português (Brasil)</a></li>
-            <li><a href="/ja" class="p-subnav__item">日本語</a></li>
-            <li><a href="/th" class="p-subnav__item">ภาษาไทย</a></li>
-            <li><a href="/he" class="p-subnav__item">עברית</a></li>
+            {% for language_hash in site.data.languages %}
+              {% assign language = language_hash[1] %}
+              <li><a href="/{{ language.code }}" class="p-subnav__item">{{ language.language }}</a></li>
+            {% endfor %}
             <li><a href="https://ru.endcoronavirus.org/" class="p-subnav__item">русский</a></li>
-            <li><a href="/cs" class="p-subnav__item">Czech</a></li>
             <li><a href="https://pt.endcoronavirus.org/" class="p-subnav__item">Português</a></li>
             <li><a href="https://nl.endcoronavirus.org/" class="p-subnav__item">Nederlands</a></li>
-            <li><a href="/it" class="p-subnav__item">Italiano</a></li>
-            <li><a href="/es" class="p-subnav__item">Español</a></li>
-            <li><a href="/de" class="p-subnav__item">Deutsch</a></li>
-            <li><a href="/ar" class="p-subnav__item">العربية</a></li>
             <li><a href="http://fr.endcoronavirus.org/" class="p-subnav__item">Français</a></li>
-            <li><a href="/" class="p-subnav__item">English</a></li>
           </ul>
         </li>
       </ul>

--- a/_updates/2020-03-11-update.md
+++ b/_updates/2020-03-11-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 11, 2020"

--- a/_updates/2020-03-12-update.md
+++ b/_updates/2020-03-12-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 12, 2020"

--- a/_updates/2020-03-13-update.md
+++ b/_updates/2020-03-13-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 13, 2020"

--- a/_updates/2020-03-14-update.md
+++ b/_updates/2020-03-14-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 14, 2020"

--- a/_updates/2020-03-15-update.md
+++ b/_updates/2020-03-15-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 15, 2020"

--- a/_updates/2020-03-16-update.md
+++ b/_updates/2020-03-16-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 16, 2020"

--- a/_updates/2020-03-17-update.md
+++ b/_updates/2020-03-17-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 17, 2020"

--- a/_updates/2020-03-18-update.md
+++ b/_updates/2020-03-18-update.md
@@ -1,7 +1,8 @@
 ---
 section: updates
+language: cs
 layout: page
-title: "Celosvětová aktualizace ke koronaviru - 18. březen 2020"
+title: Celosvětová aktualizace ke koronaviru - 18. březen 2020
 ---
 
 Chen Shen and Yaneer Bar-Yam

--- a/_updates/2020-03-19-update.md
+++ b/_updates/2020-03-19-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 19, 2020"

--- a/_updates/2020-03-20-update.md
+++ b/_updates/2020-03-20-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 20, 2020"

--- a/_updates/2020-03-21-update.md
+++ b/_updates/2020-03-21-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 21, 2020"

--- a/_updates/2020-03-22-update.md
+++ b/_updates/2020-03-22-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 22, 2020"

--- a/_updates/2020-03-23-update.md
+++ b/_updates/2020-03-23-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 23, 2020"

--- a/_updates/2020-03-24-update.md
+++ b/_updates/2020-03-24-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 24, 2020"

--- a/_updates/2020-03-25-update.md
+++ b/_updates/2020-03-25-update.md
@@ -1,4 +1,5 @@
 ---
+language: en
 section: updates
 layout: page
 title: "Global Update - March 25, 2020"

--- a/about.md
+++ b/about.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+language: en
 title: About us
 ---
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -21,6 +21,14 @@ collections:
           widget: "hidden",
           default: "updates",
         }
+      - label: Language
+        name: language
+        widget: relation
+        collection: languages
+        searchFields: ["language"]
+        valueField: code
+        displayFields: ["language"]
+        default: "en"
       - { label: "Layout", name: "layout", widget: "hidden", default: "blog" }
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Body", name: "body", widget: "markdown" }
@@ -32,6 +40,14 @@ collections:
     editor:
       preview: false
     fields: # The fields for each document, usually in front matter
+      - label: Language
+        name: language
+        widget: relation
+        collection: languages
+        searchFields: ["language"]
+        valueField: code
+        displayFields: ["language"]
+        default: "en"
       - { label: "Layout", name: "layout", widget: "hidden", default: "update" }
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Body", name: "body", widget: "markdown" }
@@ -49,6 +65,14 @@ collections:
     editor:
       preview: false
     fields:
+      - label: Language
+        name: language
+        widget: relation
+        collection: languages
+        searchFields: ["language"]
+        valueField: code
+        displayFields: ["language"]
+        default: "en"
       - { label: "Section", name: "faq", widget: "hidden", default: "faq" }
       - { label: "Layout", name: "layout", widget: "hidden", default: "blog" }
       - { label: "Question", name: "title", widget: "string" }
@@ -62,6 +86,16 @@ collections:
         name: "about"
         file: "about.md"
         fields:
+          - {
+              label: Language,
+              name: language,
+              widget: relation,
+              collection: languages,
+              searchFields: ["language"],
+              valueField: code,
+              displayFields: ["language"],
+              default: "en",
+            }
           - {
               label: "Title",
               name: "title",
@@ -94,3 +128,15 @@ collections:
             fields:
               - {label: Country, name: name, widget: string }
               - {label: Cases, name: cases, widget: string }
+  - label: "Languages"
+    name: "languages"
+    folder: "_data/languages"
+    extension: "yml"
+    format: "yml"
+    create: true
+    slug: "{{code}}"
+    editor:
+      preview: false
+    fields:
+      - { label: "Language", name: "language" , widget: string}
+      - { label: "Country Code (for url)", name: "code" , widget: string}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -133,7 +133,7 @@ collections:
     folder: "_data/languages"
     extension: "yml"
     format: "yml"
-    create: true
+    create: false
     slug: "{{code}}"
     editor:
       preview: false


### PR DESCRIPTION
This PR adds:

- Possiblity to see languages from cms: `http://127.0.0.1:4000/admin/#/collections/languages `
- A relation in each collection to be able to link a new faq/page/update to a language
- An update in the frontmatter to link each content to a language.

I can't add languages in the same way than the daily updates (in a list) because of this issue https://github.com/netlify/netlify-cms/issues/800

My idea here is to link every piece of content with a language. We should be able then to filter simply depending of the url (/uk /fr /it ....)